### PR TITLE
Added network address string parsing

### DIFF
--- a/src/SmallsOnline.Subnetting.Lib/models/ParsedNetAddressString.cs
+++ b/src/SmallsOnline.Subnetting.Lib/models/ParsedNetAddressString.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Net;
+using System.Text.RegularExpressions;
+
+namespace SmallsOnline.Subnetting.Lib.Models
+{
+    public class ParsedNetAddressString
+    {
+        public ParsedNetAddressString(string netAddressString)
+        {
+            Initialize(netAddressString);
+        }
+
+        public IPAddress IPAddress
+        {
+            get => _ipAddress;
+        }
+
+        public double CidrNotation
+        {
+            get => _cidrNotation;
+        }
+
+        private IPAddress _ipAddress;
+        private double _cidrNotation;
+
+        private void Initialize(string netAddressString)
+        {
+            Regex netAddressRegex = new("^(?'netAddress'(?:\\d{1,3}(?:\\.|)){4})\\/(?'cidrNotation'\\d{1,2})$");
+            Match netAddressMatch = netAddressRegex.Match(netAddressString);
+
+            _ipAddress = IPAddress.Parse(netAddressMatch.Groups["netAddress"].Value);
+            _cidrNotation = Convert.ToDouble(netAddressMatch.Groups["cidrNotation"].Value);
+        }
+    }
+}

--- a/src/SmallsOnline.Subnetting.Lib/models/Subnet.cs
+++ b/src/SmallsOnline.Subnetting.Lib/models/Subnet.cs
@@ -12,6 +12,12 @@ namespace SmallsOnline.Subnetting.Lib.Models
             Initialize(netAddress, cidrNotation);
         }
 
+        public Subnet(string netAddress)
+        {
+            ParsedNetAddressString parsedNetAddress = new(netAddress);
+            Initialize(parsedNetAddress.IPAddress, parsedNetAddress.CidrNotation);
+        }
+
         public IPAddress NetworkAddress
         {
             get => _networkAddress;


### PR DESCRIPTION
- The Subnet class now accepts a string that uses 'x.x.x.x/nn' as an
  input. This is done through the ParsedNetAddressString class.