### PR TITLE
Add GitHub Action with matrix build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,15 +6,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        include:
-          - dotnet: '5.0.x'
-            framework: 'net5.0'
+        framework: [ 'net5.0', 'netstandard2.1' ]
     env:
       DOTNET_NOLOGO: true
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: ${{ matrix.dotnet }}
+          dotnet-version: '5.0.x'
       - run: dotnet restore
       - run: dotnet publish --framework ${{ matrix.framework }}


### PR DESCRIPTION
This adds a GitHub action that runs the dotnet commands in the README. Also adds a matrix build environment option for easy addition of future framework versions. I attempted to add ~~2.1 and~~ 4.5 but ~~2.1 doesn't seem to be supported by the runners and~~ 4.5 doesn't seem to build successfully.